### PR TITLE
[feat] BaseCode enum 및 ApiResponse 클래스 추가

### DIFF
--- a/src/main/java/com/ureca/yoajungadmin/common/ApiResponse.java
+++ b/src/main/java/com/ureca/yoajungadmin/common/ApiResponse.java
@@ -1,0 +1,47 @@
+package com.ureca.yoajungadmin.common;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final String code;
+    private final HttpStatus status;
+    private final String message;
+    private final T data;
+    private final LocalDateTime timestamp;
+
+    private ApiResponse(BaseCode baseCode, T data) {
+        this.code = baseCode.getCode();
+        this.status = baseCode.getStatus();
+        this.message = baseCode.getMessage();
+        this.data = data;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    /**
+     * 주어진 BaseCode와 데이터를 사용해 ApiResponse를 생성합니다.
+     *
+     * @param code 상태 코드, HTTP 상태, 메시지를 담은 BaseCode
+     * @param data 응답 페이로드 (없으면 {@code null})
+     * @param <T>  페이로드 타입
+     * @return ApiResponse 인스턴스
+     */
+    public static <T> ApiResponse<T> of(BaseCode code, T data) {
+        return new ApiResponse<>(code, data);
+    }
+
+    /**
+     * 주어진 BaseCode를 사용해 데이터 없이 성공 응답을 생성합니다.
+     *
+     * @param code 상태 코드, HTTP 상태, 메시지를 담은 BaseCode
+     * @param <T> 페이로드 타입
+     * @return ApiResponse 인스턴스
+     */
+    public static <T> ApiResponse<T> ok(BaseCode code) {
+        return new ApiResponse<>(code, null);
+    }
+}

--- a/src/main/java/com/ureca/yoajungadmin/common/BaseCode.java
+++ b/src/main/java/com/ureca/yoajungadmin/common/BaseCode.java
@@ -1,0 +1,37 @@
+package com.ureca.yoajungadmin.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BaseCode {
+    // common
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR_500",HttpStatus.INTERNAL_SERVER_ERROR,"예기치 못한 오류가 발생했습니다"),
+    STATUS_OK("STATUS_OK_200", HttpStatus.OK, "서버가 정상적으로 동작 중입니다."),
+    STATUS_AUTHENTICATED("STATUS_AUTHENTICATED_200", HttpStatus.OK, "로그인된 사용자입니다."),
+    STATUS_UNAUTHORIZED("STATUS_UNAUTHORIZED_401", HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+
+    // Plan
+    PLAN_DETAIL_SUCCESS("FIND_PLAN_DETAIL_200", HttpStatus.OK, "요금제 상세 조회에 성공했습니다."),
+    PLAN_LIST_SUCCESS("READ_PLAN_LIST_200", HttpStatus.OK, "요금제 목록 조회에 성공했습니다."),
+    PLAN_NOT_FOUND("NOT_FOUND_PLAN_404", HttpStatus.NOT_FOUND, "해당 요금제를 찾을 수 없습니다."),
+
+    // Review
+    REVIEW_CREATE_SUCCESS("CREATE_REVIEW_201", HttpStatus.CREATED, "리뷰 생성에 성공했습니다."),
+    REVIEW_UPDATE_SUCCESS("UPDATE_REVIEW_200", HttpStatus.OK, "리뷰 수정에 성공했습니다."),
+    REVIEW_DELETE_SUCCESS("DELETE_REVIEW_200", HttpStatus.OK, "리뷰 삭제에 성공했습니다."),
+    REVIEW_NOT_FOUND("NOT_FOUND_REVIEW_404", HttpStatus.NOT_FOUND, "해당 리뷰를 찾을 수 없습니다."),
+
+    // User
+    USER_SIGNUP_SUCCESS("SIGNUP_USER_201", HttpStatus.CREATED, "회원가입에 성공했습니다."),
+    USER_NOT_FOUND("NOT_FOUND_USER_404", HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+
+    // Chat
+    CHAT_SAVE_SUCCESS("SAVE_CHAT_201", HttpStatus.CREATED, "채팅 저장에 성공했습니다.");
+
+    private final String code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/ureca/yoajungadmin/common/BaseTimeEntity.java
+++ b/src/main/java/com/ureca/yoajungadmin/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.ureca.yoajungadmin.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/ureca/yoajungadmin/common/JpaAuditingConfig.java
+++ b/src/main/java/com/ureca/yoajungadmin/common/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.ureca.yoajungadmin.common;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}


### PR DESCRIPTION
## 개요
<!-- 이 PR이 어떤 기능/수정/버그 해결 등을 위한 것인지 간단히 설명해주세요. -->
- API 응답 구조를 통일하기 위해 `BaseCode` enum과 `ApiResponse` 클래스를 추가했습니다.
- JPA Auditing을 위한 `BaseTimeEntity` 및 설정 클래스를 함께 적용하여 생성/수정 시각 자동 저장을 처리합니다.

## 변경 사항
- `BaseCode` enum 추가  
  - HTTP 상태 코드, 내부 고유 코드, 메시지를 한 곳에서 관리  
  - `PLAN`, `REVIEW`, `USER`, `CHAT` 등 도메인별 상태 코드를 정의  
  
- `ApiResponse<T>` 클래스 추가  
  - `BaseCode`를 기반으로 `{ code, status, message, data, timestamp }` 형태의 응답 생성  
  - `ApiResponse.of(BaseCode, data)` / `ApiResponse.ok(BaseCode)` 팩토리 메서드 제공  
  
- JPA Auditing 설정 추가  
  - `BaseTimeEntity` (@MappedSuperclass) : `@CreatedDate`, `@LastModifiedDate` 필드 정의  
  - `JpaAuditingConfig` (`@EnableJpaAuditing`) 클래스 추가  
  
- 전역 예외 처리 시 `BaseCode`를 활용하여 일관된 에러 응답 보장

